### PR TITLE
Fix reading last line from report

### DIFF
--- a/scripts/linter.py
+++ b/scripts/linter.py
@@ -33,11 +33,14 @@ def lint(report, reviewName):
             (line.startswith("**Recommendation:**") and len(line) < len("**Recommendation:**") + 5) or
             (line.startswith("**" + reviewName + ":**") and len(line) < len("**" + reviewName + ":**") + 5)):
             
-            # There might be more than one empty lines following the header, remove them
-            while report[lineNumber + 1] == "":
+           # There might be more than one empty lines following the header, remove them
+            while lineNumber + 1 < len(report):
+                if report[lineNumber + 1] != "": break
                 del report[lineNumber + 1]
+                
 
-            nextLine = report[lineNumber + 1]
+            # if next line is out of range then stop
+            if lineNumber + 1 >= len(report): break
             # If it's a list, code or quote, don't merge
             if (not nextLine.lstrip().startswith("-") and 
                 not nextLine.lstrip().startswith("1.") and 

--- a/scripts/linter.py
+++ b/scripts/linter.py
@@ -41,6 +41,9 @@ def lint(report, reviewName):
 
             # if next line is out of range then stop
             if lineNumber + 1 >= len(report): break
+
+            nextLine = report[lineNumber + 1]
+            
             # If it's a list, code or quote, don't merge
             if (not nextLine.lstrip().startswith("-") and 
                 not nextLine.lstrip().startswith("1.") and 


### PR DESCRIPTION
When the last line of report.md is, eg.:
```
**Review Name:**

```  

linter.py is throwing an error `IndexError: list index out of range`, because it tries to get next empty line with:
```
while report[lineNumber + 1] == "":
                del report[lineNumber + 1]
```

This PR add a check if report[lineNumber + 1] exists

